### PR TITLE
Fix issue with output token decimals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ const jupiterSwap = async ({
           ); 
           process.stdout.write(`${inputToken.symbol} -> `);
           process.stdout.write(
-            `${swapResult.outputAmount / (10 ** inputToken.decimals)} `
+            `${swapResult.outputAmount / (10 ** outputToken.decimals)} `
           );
           process.stdout.write(`${outputToken.symbol}: `);
           console.log(`https://solscan.io/tx/${swapResult.txid}`);


### PR DESCRIPTION
The output token amount from the swap was using the input token's decimals. Would work of if they matches but fails for tokens like USDC to SOL swaps. This fixes it to use the correct decimal number for the correct display of the swap amount on screen to the user.